### PR TITLE
fix: Correct VerifiableURI encoding format in SKILL.md

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -192,22 +192,58 @@ const followData = lsp26Iface.encodeFunctionData('follow', [targetAddress]);
 
 ## VerifiableURI (LSP2)
 
-Format: `0x` + `00006f357c6a0020` (8-byte header) + `keccak256hash` (32 bytes) + `url as UTF-8 hex`
+⚠️ **IMPORTANT: The format described below (with hashLength) does NOT work with the LUKSO wallet.**
 
-Header = verificationMethod(2) + hashFunction(4=keccak256(utf8)) + hashLength(2=0x0020).
+The wallet expects the **legacy format** (without hashLength):
 
-Decoding: skip 80 hex chars (2 + 8 + 4 + 64 + 2 prefix), rest = UTF-8 URL.
+```
+0x + hashFunction (4 bytes) + keccak256(json) (32 bytes) + url (UTF-8 hex)
+= 89 bytes for ipfs://Qm... URLs
+```
 
-**Common mistakes:** forgetting `0020` hash length bytes, not pinning IPFS before on-chain tx, hash mismatch from re-serialization.
+### Legacy Format (WORKS)
+
+```javascript
+const hashFunction = "6f357c6a"; // keccak256(utf8)
+
+// 1. Upload JSON to IPFS and get CID
+const cid = "Qm..."; 
+const url = "ipfs://" + cid;
+
+// 2. Fetch EXACT content from IPFS (important!)
+const jsonFromIPFS = await fetch("https://gateway.pinata.cloud/ipfs/" + cid);
+
+// 3. Compute hash of exact content
+const jsonHash = ethers.keccak256(ethers.toUtf8Bytes(jsonFromIPFS));
+
+// 4. Build VerifiableURI (legacy format - 89 bytes)
+const urlHex = ethers.hexlify(ethers.toUtf8Bytes(url)).slice(2);
+const verifiableUri = "0x" + hashFunction + jsonHash.slice(2) + urlHex;
+```
+
+**Result:** 89 bytes total
+
+### Old Format (DOES NOT WORK)
+
+The documentation previously showed this format with hashLength:
+
+```
+Header = verificationMethod(2) + hashFunction(4=keccak256(utf8)) + hashLength(2=0x0020)
+```
+
+**This produces ~106 bytes and the hash verification fails.** Do not use.
 
 ### LSP3 Profile Update Procedure
 1. Read current: `getData(0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5)` → decode VerifiableURI → fetch JSON
 2. Modify JSON
 3. Use `{ verification: { method: "keccak256(bytes)", data: "0x..." }, url: "ipfs://..." }` for images
-4. Pin images + JSON to IPFS, verify accessible via gateway
-5. Compute `keccak256(exactJsonBytes)`, encode VerifiableURI
-6. `setData(LSP3_KEY, verifiableUri)` from controller
-7. Verify: read back, decode, fetch, confirm
+4. **Pin JSON to IPFS, verify accessible via gateway**
+5. **Fetch exact content from IPFS** (not your local JSON - must match what's on IPFS)
+6. Compute `keccak256(exactJsonBytes)`, encode using legacy format (see above)
+7. `setData(LSP3_KEY, verifiableUri)` from controller
+8. Verify: read back, decode, fetch, confirm
+
+**Critical:** The hash must be computed from the exact bytes returned by IPFS, not from your original JSON string. JSON.stringify can add whitespace differences.
 
 LSP3 key: `0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5`
 LSP28 key: `0x724141d9918ce69e6b8afcf53a91748466086ba2c74b94cab43c649ae2ac23ff`

--- a/skill/commands/update-profile.js
+++ b/skill/commands/update-profile.js
@@ -1,0 +1,183 @@
+/**
+ * Update Universal Profile LSP3 Metadata
+ * 
+ * This script uploads profile JSON to IPFS and updates the profile on-chain.
+ * 
+ * Usage:
+ *   node update-profile.js <up-address> <private-key> <json-file>
+ * 
+ * Example:
+ *   node update-profile.js 0x1234... 0xabc123... profile.json
+ */
+
+const { ethers } = require('ethers');
+const https = require('https');
+const fs = require('fs');
+const FormData = require('form-data');
+
+// Configuration
+const LUKSO_MAINNET_RPC = 'https://42.rpc.thirdweb.com';
+const LUKSO_TESTNET_RPC = 'https://rpc.testnet.lukso.network';
+const LSP3_PROFILE_KEY = '0x5ef83ad9559053e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5';
+
+// Pinata API (update with your credentials)
+const PINATA_API_KEY = process.env.PINATA_API_KEY || 'your-api-key';
+const PINATA_SECRET = process.env.PINATA_SECRET || 'your-secret';
+
+/**
+ * Upload JSON to IPFS via Pinata
+ */
+async function uploadToIPFS(jsonData) {
+  return new Promise((resolve, reject) => {
+    const form = new FormData();
+    form.append('file', JSON.stringify(jsonData), { 
+      filename: 'profile.json', 
+      contentType: 'application/json' 
+    });
+
+    const options = {
+      hostname: 'api.pinata.cloud',
+      path: '/pinning/pinFileToIPFS',
+      method: 'POST',
+      headers: {
+        ...form.getHeaders(),
+        'pinata_api_key': PINATA_API_KEY,
+        'pinata_secret_api_key': PINATA_SECRET
+      }
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try {
+          const result = JSON.parse(data);
+          if (result.IpfsHash) {
+            resolve(result.IpfsHash);
+          } else {
+            reject(new Error(`Pinata error: ${data}`));
+          }
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+
+    req.on('error', reject);
+    form.pipe(req);
+  });
+}
+
+/**
+ * Fetch content from IPFS gateway
+ */
+async function fetchFromIPFS(cid, gateway = 'https://gateway.pinata.cloud') {
+  return new Promise((resolve, reject) => {
+    https.get(`${gateway}/ipfs/${cid}`, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve(data));
+    }).on('error', reject);
+  });
+}
+
+/**
+ * Build VerifiableURI in legacy format (the only one that works)
+ */
+function buildVerifiableURI(jsonContent, ipfsCid) {
+  const hashFunction = '6f357c6a'; // keccak256(utf8)
+  
+  // Compute hash of EXACT content from IPFS
+  const jsonHash = ethers.keccak256(ethers.toUtf8Bytes(jsonContent));
+  
+  // Build URL
+  const url = `ipfs://${ipfsCid}`;
+  const urlHex = ethers.hexlify(ethers.toUtf8Bytes(url)).slice(2);
+  
+  // Legacy format: hashFunction(4) + hash(32) + url
+  const verifiableUri = '0x' + hashFunction + jsonHash.slice(2) + urlHex;
+  
+  return {
+    verifiableUri,
+    jsonHash,
+    url,
+    bytes: (verifiableUri.length - 2) / 2
+  };
+}
+
+/**
+ * Update profile on-chain
+ */
+async function updateProfile(upAddress, privateKey, jsonData) {
+  const provider = new ethers.JsonRpcProvider(LUKSO_MAINNET_RPC);
+  const wallet = new ethers.Wallet(privateKey, provider);
+  
+  console.log('📤 Uploading JSON to IPFS...');
+  const cid = await uploadToIPFS(jsonData);
+  console.log('✅ IPFS CID:', cid);
+  
+  console.log('🔄 Fetching exact content from IPFS...');
+  const exactJson = await fetchFromIPFS(cid);
+  
+  console.log('🔐 Building VerifiableURI (legacy format)...');
+  const { verifiableUri, jsonHash, url, bytes } = buildVerifiableURI(exactJson, cid);
+  
+  console.log('   Hash:', jsonHash);
+  console.log('   URL:', url);
+  console.log('   Bytes:', bytes);
+  
+  // Verify hash matches
+  const verifyHash = ethers.keccak256(ethers.toUtf8Bytes(exactJson));
+  if (verifyHash !== jsonHash) {
+    throw new Error('Hash verification failed!');
+  }
+  console.log('✅ Hash verified');
+  
+  console.log('📝 Sending transaction to update profile...');
+  const up = new ethers.Contract(upAddress, [
+    'function setData(bytes32 dataKey, bytes dataValue) external'
+  ], wallet);
+  
+  const tx = await up.setData(LSP3_PROFILE_KEY, verifiableUri);
+  console.log('   Tx hash:', tx.hash);
+  
+  const receipt = await tx.wait();
+  console.log('✅ Profile updated!');
+  console.log('   Block:', receipt.blockNumber);
+  console.log('   Gas used:', receipt.gasUsed.toString());
+  
+  return { cid, txHash: tx.hash, block: receipt.blockNumber };
+}
+
+// CLI
+const args = process.argv.slice(2);
+if (args.length < 3) {
+  console.log('Usage: node update-profile.js <up-address> <private-key> <json-file>');
+  console.log('');
+  console.log('Environment variables:');
+  console.log('  PINATA_API_KEY   - Your Pinata API key');
+  console.log('  PINATA_SECRET    - Your Pinata secret');
+  process.exit(1);
+}
+
+const [upAddress, privateKey, jsonFile] = args;
+
+// Load JSON
+let jsonData;
+try {
+  const jsonContent = fs.readFileSync(jsonFile, 'utf8');
+  jsonData = JSON.parse(jsonContent);
+} catch (e) {
+  console.error('Error reading JSON file:', e.message);
+  process.exit(1);
+}
+
+// Run
+updateProfile(upAddress, privateKey, jsonData)
+  .then(result => {
+    console.log('\n🎉 Done!', result);
+  })
+  .catch(e => {
+    console.error('Error:', e.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
The documentation showed a format with hashLength (~106 bytes) that does not work with the LUKSO wallet. This fix:

- Documents the legacy format (89 bytes) that actually works
- Adds working JavaScript code example
- Explains why fetching from IPFS is critical (JSON.stringify differences)
- Adds update-profile.js command for automated profile updates

Tested on LUKSO mainnet with real transaction.